### PR TITLE
fix : フェードイン、フェードアウトの動作修正

### DIFF
--- a/Assets/Prefabs/System/SETUPS.prefab
+++ b/Assets/Prefabs/System/SETUPS.prefab
@@ -273,7 +273,7 @@ Transform:
   m_GameObject: {fileID: 2414261462157141018}
   serializedVersion: 2
   m_LocalRotation: {x: 0.21615916, y: 0.67325723, z: -0.21615916, w: 0.67325723}
-  m_LocalPosition: {x: -11.594467, y: 9.204685, z: 1.0000015}
+  m_LocalPosition: {x: -11.594467, y: 9.204685, z: 0.0000015497208}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -659,7 +659,7 @@ Transform:
   m_GameObject: {fileID: 7565822382810839821}
   serializedVersion: 2
   m_LocalRotation: {x: 0.21615916, y: 0.67325723, z: -0.21615916, w: 0.67325723}
-  m_LocalPosition: {x: -19, y: 7.45, z: 2.99}
+  m_LocalPosition: {x: -19, y: 7.45, z: 1.99}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1055,6 +1055,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5219001806242368570}
     m_Modifications:
+    - target: {fileID: 1061554034291184409, guid: 0eff599529e0f9748b6c0f7ad71cd263, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -19.99997
+      objectReference: {fileID: 0}
     - target: {fileID: 6393126255539481697, guid: 0eff599529e0f9748b6c0f7ad71cd263, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -1143,6 +1147,10 @@ PrefabInstance:
       propertyPath: fadeObject
       value: 
       objectReference: {fileID: 6755424508254920557}
+    - target: {fileID: 6737950377242035633, guid: 0eff599529e0f9748b6c0f7ad71cd263, type: 3}
+      propertyPath: uiAppearSeconds
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1371,6 +1379,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5219001806242368570}
     m_Modifications:
+    - target: {fileID: 1454224760816420598, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2930246302368397930, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7350803714451616679, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
       propertyPath: m_Name
       value: FadeCanvas
@@ -1455,10 +1471,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9077775610066411368, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5785395772899099013, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 472901862988741016}
   m_SourcePrefab: {fileID: 100100000, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
 --- !u!224 &5978914396018351101 stripped
 RectTransform:
@@ -1470,6 +1490,26 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7350803714451616679, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
   m_PrefabInstance: {fileID: 4306386567611690186}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &7749147987798961487 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5785395772899099013, guid: 2f0ee3dcd5beee941920723a49d594bb, type: 3}
+  m_PrefabInstance: {fileID: 4306386567611690186}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &472901862988741016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7749147987798961487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ef121ca781a6b74db382d90f3e2b0d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fadeSpeed: 0.65
+  fadeinDeray: 30
+  time: 0
 --- !u!1001 &5140397417653997167
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1593,7 +1633,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5603580423293017532, guid: 7fd4897dfcb20f04ca5ebe5dc7b56992, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5603580423293017532, guid: 7fd4897dfcb20f04ca5ebe5dc7b56992, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scenes/dev/PanelPuzzle/PanelPuzzle1.unity
+++ b/Assets/Scenes/dev/PanelPuzzle/PanelPuzzle1.unity
@@ -3799,17 +3799,45 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 364782542013693925, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_ReferencePixelsPerUnit
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 535137882271034745, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -19.99997
+      objectReference: {fileID: 0}
     - target: {fileID: 788211061822199728, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.0000015497208
+      objectReference: {fileID: 0}
+    - target: {fileID: 1398658749821081248, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1398658749821081248, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1398658749821081248, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_Color.r
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3394540720467042579, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3453463163881155132, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3740987094845606514, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_Name
       value: SETUPS
+      objectReference: {fileID: 0}
+    - target: {fileID: 5060329739625214882, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: fadeSpeed
+      value: 0.65
       objectReference: {fileID: 0}
     - target: {fileID: 5219001806242368570, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3855,6 +3883,14 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 1.99
       objectReference: {fileID: 0}
+    - target: {fileID: 6076577453615692753, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: isApear
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6076577453615692753, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: uiAppearSeconds
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 6843784987305697534, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: '_spawnPoints.Array.data[0]'
       value: 
@@ -3863,6 +3899,10 @@ PrefabInstance:
       propertyPath: '_spawnPoints.Array.data[1]'
       value: 
       objectReference: {fileID: 373526526}
+    - target: {fileID: 7749147987798961487, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/dev/PanelPuzzle/PanelPuzzle2.unity
+++ b/Assets/Scenes/dev/PanelPuzzle/PanelPuzzle2.unity
@@ -4285,6 +4285,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3453463163881155132, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3740987094845606514, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_Name
       value: SETUPS
@@ -4320,6 +4324,10 @@ PrefabInstance:
     - target: {fileID: 4999561659956248414, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_Color.a
       value: 0.7372549
+      objectReference: {fileID: 0}
+    - target: {fileID: 5060329739625214882, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: fadeSpeed
+      value: 0.65
       objectReference: {fileID: 0}
     - target: {fileID: 5219001806242368570, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4380,6 +4388,10 @@ PrefabInstance:
     - target: {fileID: 6058260439838976373, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.z
       value: 3.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 6076577453615692753, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: uiAppearSeconds
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6112570238065172459, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_Color.b
@@ -6874,6 +6886,10 @@ PrefabInstance:
     - target: {fileID: 6507986907359979145, guid: 0eff599529e0f9748b6c0f7ad71cd263, type: 3}
       propertyPath: m_Name
       value: GameStartCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 6507986907359979145, guid: 0eff599529e0f9748b6c0f7ad71cd263, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/dev/PanelPuzzle/PanelPuzzle3.unity
+++ b/Assets/Scenes/dev/PanelPuzzle/PanelPuzzle3.unity
@@ -8662,6 +8662,10 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3453463163881155132, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3740987094845606514, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_Name
       value: SETUPS
@@ -8694,6 +8698,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+    - target: {fileID: 5060329739625214882, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: fadeSpeed
+      value: 0.65
+      objectReference: {fileID: 0}
     - target: {fileID: 5219001806242368570, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -8741,6 +8749,10 @@ PrefabInstance:
     - target: {fileID: 6058260439838976373, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_LocalPosition.z
       value: 1.99
+      objectReference: {fileID: 0}
+    - target: {fileID: 6076577453615692753, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
+      propertyPath: uiAppearSeconds
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6112570238065172459, guid: 22504c02c7738e3479fdb8dcb6dbebda, type: 3}
       propertyPath: m_Color.b

--- a/Assets/Scripts/Manager/GameClearManager.cs
+++ b/Assets/Scripts/Manager/GameClearManager.cs
@@ -13,8 +13,11 @@ public class GameClearManager : MonoBehaviour
     //[SerializeField] private Text _clearTimeText;
     [SerializeField] private string nextSceneName = "NextScene"; // 次に移動するシーン�?
     [NonSerializedAttribute] public bool isFinish = false;
+    static public bool FadeOut = false;
+
     private void Start()
     {
+        FadeOut = false;
     }
 
     void OnCollisionEnter(Collision collision)
@@ -28,8 +31,8 @@ public class GameClearManager : MonoBehaviour
                 SetClearGameByFinish();
         }
     }
-    [SerializeField] private float fadeOutDelay = 3.0f;
-    [SerializeField] private float loadNextSceneDelay = 4.0f;
+    [SerializeField] private float fadeOutDelay = 0.0f;
+    [SerializeField] private float loadNextSceneDelay = 0.0f;
     public void SetClearGameByFinish()
     {
         if (isFinish) return;
@@ -42,8 +45,8 @@ public class GameClearManager : MonoBehaviour
 
     private void SetFadeOut()
     {
-        fadeObject = GameObject.FindGameObjectWithTag("FadeObject");
-        fadeObject.GetComponent<Animator>().Play("FadeOut");
+        //FadeInImgManagerへ
+        FadeOut = true;
     }
 
     void LoadNextScene() { SceneManager.LoadScene(nextSceneName); }

--- a/Assets/Scripts/UI/CallStartUI.cs
+++ b/Assets/Scripts/UI/CallStartUI.cs
@@ -1,11 +1,11 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 public class GameStartUI : MonoBehaviour
 {
     //ゲームオーバー、クリアと同じように、少し止めてから処理
     [SerializeField] private Vector3 firstPosition = new Vector3(0.0f, 0.0f, 0.0f);
     [SerializeField] private bool isApear = false;  //UI表示中かどうか
-    [SerializeField] private float uiAppearSeconds = 4.0f;//UIの表示時間 (秒)
+    [SerializeField] private float uiAppearSeconds = 2.0f;//UIの表示時間 (秒)
     [SerializeField] private float decelTimeSpeedNDeltaTime = 1.0f;//表示時間を減らす速度
 
     [SerializeField] private GameObject fadeObject;

--- a/Assets/Scripts/UI/FadeInImgManager.cs
+++ b/Assets/Scripts/UI/FadeInImgManager.cs
@@ -1,21 +1,46 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 public class FadeInImgManager : MonoBehaviour
 {
     Image img;
-    [SerializeField] private float fadeSpeed = 1.0f; // Alpha units per second
+    [SerializeField] private float fadeSpeed = 0.65f; // Alpha units per second
+    [SerializeField] private float fadeinDeray = 30.0f; //フェードインに入るまでのディレイ時間
+    [SerializeField] private float time = 0.0f;
 
     void Start()
     {
         img = GetComponent<Image>();
-        if(!img.enabled) img.enabled = true;
+        if (!img.enabled) img.enabled = true;
     }
 
     void Update()
     {
-        Color c = img.color;
-        c.a -= fadeSpeed * Time.unscaledDeltaTime;
-        img.color = c;
+        if (GameClearManager.FadeOut == true)
+        {
+            Color c = img.color;
+            c.a += (fadeSpeed * 2) * Time.unscaledDeltaTime;
+            if (c.a >= 1)
+            {
+                c.a = 1;
+            }
+            img.color = c;
+        }
+
+        else
+        {
+            time++;
+
+            if (time >= 30.0f)
+            {
+                Color c = img.color;
+                c.a -= fadeSpeed * Time.unscaledDeltaTime;
+                if (c.a <= 0)
+                {
+                    c.a = 0;
+                }
+                img.color = c;
+            }
+        }
     }
 }


### PR DESCRIPTION
前回のブランチの作成場所ミスしたためこのブランチを使用しフェードイン、フェードアウトのfixをしました

FadeInManagerのFadeSpeedで黒から透明に変わるスピードの調整
フェードインのキャンバスの優先度を前に移動

フェードインのタイム設定
SETUPS->GameStartCanvas->GameStartUIのスクリプトのUiAppearSecondsがストップする時間
SETUPS->FadeCanvas->FadeCanvasImgManagerのスクリプトのFadeSpeedが黒から透明になっていく速さ
SETUPS->FadeCanvas->FadeCanvasImgManagerのスクリプトのFadeinDerayが透明になる前に少しおくディレイ

ステージ２の無駄なゲームスタートキャンバスを削除

